### PR TITLE
Fix gotk3 build failure in install_coyim_tails.sh

### DIFF
--- a/install_coyim_tails.sh
+++ b/install_coyim_tails.sh
@@ -12,7 +12,7 @@ git clone https://github.com/golang/net.git $GOPATH/src/golang.org/x/net
 git clone https://github.com/golang/crypto.git $GOPATH/src/golang.org/x/crypto
 
 GTK_VERSION=$(pkg-config --modversion gtk+-3.0 | tr . _ | cut -d '_' -f 1-2)
-go get -u -v -tags "gtk_${GTK_VERSION}" github.com/gotk3/gotk3
+go get -u -v -tags "gtk_${GTK_VERSION}" github.com/gotk3/gotk3/gtk
 go get -u -v -tags github.com/twstrike/coyim
 
 $GOPATH/bin/coyim


### PR DESCRIPTION
"Stupid gotk3 moving stuff around breaking stuff" problem fixed on Tails. 

Works for me, at least, but would like if someone else could confirm?

For background: the path of the gtk stuff in the upstream repo changed, breaking this script. This change reflects that and works (I think, I got it to build at least, hence asking someone else to confirm).