### PR TITLE
Update README.md - Ubuntu installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The GUI version requires GTK+ >= 3.6.16, which installation depends on your OS:
 
 **Ubuntu:**
 
-	sudo apt-get install -qq -y gtk+3.0 libgtk-3-dev
+	sudo apt-get install gtk+3.0 libgtk-3-dev
 
 **Mac:**
 


### PR DESCRIPTION
Removed "Automatic yes to prompt" (`-y`) and "Quiet" (`-qq`) options from `apt-get install` command, in "Installation instructions > GUI version > Ubuntu".

In my experience, most installation instructions don't include these options, and they make the installation process a bit more opaque. I believe they're not as well-known as the generic `apt-get install packagename` command.

By removing these options, we give users more control and agency over the installation of additional dependencies and the installation process overall.