### PR TITLE
Small fixes - menu accels and unified window title

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,7 @@
 {
 	"ImportPath": "github.com/twstrike/coyim",
 	"GoVersion": "go1.5",
+	"GodepVersion": "v60",
 	"Packages": [
 		"./..."
 	],
@@ -44,43 +45,43 @@
 		},
 		{
 			"ImportPath": "github.com/twstrike/gotk3adapter/gdka",
-			"Rev": "9d707112ca95d5a94c29e4771b6b451dc75fe4c8"
+			"Rev": "6d721d6a308ce013142fcd2dcdbc58771e99919d"
 		},
 		{
 			"ImportPath": "github.com/twstrike/gotk3adapter/gdki",
-			"Rev": "9d707112ca95d5a94c29e4771b6b451dc75fe4c8"
+			"Rev": "6d721d6a308ce013142fcd2dcdbc58771e99919d"
 		},
 		{
 			"ImportPath": "github.com/twstrike/gotk3adapter/glib_mock",
-			"Rev": "9d707112ca95d5a94c29e4771b6b451dc75fe4c8"
+			"Rev": "6d721d6a308ce013142fcd2dcdbc58771e99919d"
 		},
 		{
 			"ImportPath": "github.com/twstrike/gotk3adapter/gliba",
-			"Rev": "9d707112ca95d5a94c29e4771b6b451dc75fe4c8"
+			"Rev": "6d721d6a308ce013142fcd2dcdbc58771e99919d"
 		},
 		{
 			"ImportPath": "github.com/twstrike/gotk3adapter/glibi",
-			"Rev": "9d707112ca95d5a94c29e4771b6b451dc75fe4c8"
+			"Rev": "6d721d6a308ce013142fcd2dcdbc58771e99919d"
 		},
 		{
 			"ImportPath": "github.com/twstrike/gotk3adapter/gtk_mock",
-			"Rev": "9d707112ca95d5a94c29e4771b6b451dc75fe4c8"
+			"Rev": "6d721d6a308ce013142fcd2dcdbc58771e99919d"
 		},
 		{
 			"ImportPath": "github.com/twstrike/gotk3adapter/gtka",
-			"Rev": "9d707112ca95d5a94c29e4771b6b451dc75fe4c8"
+			"Rev": "6d721d6a308ce013142fcd2dcdbc58771e99919d"
 		},
 		{
 			"ImportPath": "github.com/twstrike/gotk3adapter/gtki",
-			"Rev": "9d707112ca95d5a94c29e4771b6b451dc75fe4c8"
+			"Rev": "6d721d6a308ce013142fcd2dcdbc58771e99919d"
 		},
 		{
 			"ImportPath": "github.com/twstrike/gotk3adapter/pangoa",
-			"Rev": "9d707112ca95d5a94c29e4771b6b451dc75fe4c8"
+			"Rev": "6d721d6a308ce013142fcd2dcdbc58771e99919d"
 		},
 		{
 			"ImportPath": "github.com/twstrike/gotk3adapter/pangoi",
-			"Rev": "9d707112ca95d5a94c29e4771b6b451dc75fe4c8"
+			"Rev": "6d721d6a308ce013142fcd2dcdbc58771e99919d"
 		},
 		{
 			"ImportPath": "github.com/twstrike/otr3",

--- a/Godeps/_workspace/src/github.com/twstrike/gotk3adapter/gtk_mock/window.go
+++ b/Godeps/_workspace/src/github.com/twstrike/gotk3adapter/gtk_mock/window.go
@@ -20,6 +20,12 @@ func (*MockWindow) HasToplevelFocus() bool {
 	return false
 }
 
+func (*MockWindow) Fullscreen() {
+}
+
+func (*MockWindow) Unfullscreen() {
+}
+
 func (*MockWindow) IsActive() bool {
 	return false
 }

--- a/Godeps/_workspace/src/github.com/twstrike/gotk3adapter/gtka/window.go
+++ b/Godeps/_workspace/src/github.com/twstrike/gotk3adapter/gtka/window.go
@@ -85,3 +85,11 @@ func (v *window) Present() {
 func (v *window) HasToplevelFocus() bool {
 	return v.internal.HasToplevelFocus()
 }
+
+func (v *window) Fullscreen() {
+	v.internal.Fullscreen()
+}
+
+func (v *window) Unfullscreen() {
+	v.internal.Unfullscreen()
+}

--- a/Godeps/_workspace/src/github.com/twstrike/gotk3adapter/gtki/window.go
+++ b/Godeps/_workspace/src/github.com/twstrike/gotk3adapter/gtki/window.go
@@ -9,6 +9,8 @@ type Window interface {
 	GetTitle() string
 	HasToplevelFocus() bool
 	IsActive() bool
+	Fullscreen()
+	Unfullscreen()
 	Present()
 	Resize(int, int)
 	SetApplication(Application)

--- a/gui/definitions/ConversationPane.xml
+++ b/gui/definitions/ConversationPane.xml
@@ -9,7 +9,8 @@
         <child>
           <object class="GtkMenuItem" id="conversationMenu">
             <property name="visible">true</property>
-            <property name="label" translatable="yes">Developer options</property>
+            <property name="label" translatable="yes">_Developer options</property>
+            <property name="use-underline">True</property>
             <child type="submenu">
               <object class="GtkMenu" id="menu">
                 <property name="visible">true</property>

--- a/gui/definitions/Main.xml
+++ b/gui/definitions/Main.xml
@@ -19,7 +19,8 @@
                 <child>
                   <object class="GtkMenuItem" id="ContactsMenu">
                     <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Contacts</property>
+                    <property name="label" translatable="yes">_Contacts</property>
+                    <property name="use-underline">True</property>
                     <child type="submenu">
                       <object class="GtkMenu" id="menu">
                         <property name="can_focus">False</property>
@@ -37,13 +38,15 @@
                 <child>
                   <object class="GtkMenuItem" id="AccountsMenu">
                     <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Accounts</property>
+                    <property name="label" translatable="yes">_Accounts</property>
+                    <property name="use-underline">True</property>
                   </object>
                 </child>
                 <child>
                   <object class="GtkMenuItem" id="ViewMenu">
                     <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">View</property>
+                    <property name="label" translatable="yes">_View</property>
+                    <property name="use-underline">True</property>
                     <child type="submenu">
                       <object class="GtkMenu" id="menu2">
                         <property name="can_focus">False</property>

--- a/gui/definitions/conversation_pane.go
+++ b/gui/definitions/conversation_pane.go
@@ -18,7 +18,8 @@ func (*defConversationPane) String() string {
         <child>
           <object class="GtkMenuItem" id="conversationMenu">
             <property name="visible">true</property>
-            <property name="label" translatable="yes">Developer options</property>
+            <property name="label" translatable="yes">_Developer options</property>
+            <property name="use-underline">True</property>
             <child type="submenu">
               <object class="GtkMenu" id="menu">
                 <property name="visible">true</property>

--- a/gui/definitions/main.go
+++ b/gui/definitions/main.go
@@ -28,7 +28,8 @@ func (*defMain) String() string {
                 <child>
                   <object class="GtkMenuItem" id="ContactsMenu">
                     <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Contacts</property>
+                    <property name="label" translatable="yes">_Contacts</property>
+                    <property name="use-underline">True</property>
                     <child type="submenu">
                       <object class="GtkMenu" id="menu">
                         <property name="can_focus">False</property>
@@ -46,13 +47,15 @@ func (*defMain) String() string {
                 <child>
                   <object class="GtkMenuItem" id="AccountsMenu">
                     <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Accounts</property>
+                    <property name="label" translatable="yes">_Accounts</property>
+                    <property name="use-underline">True</property>
                   </object>
                 </child>
                 <child>
                   <object class="GtkMenuItem" id="ViewMenu">
                     <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">View</property>
+                    <property name="label" translatable="yes">_View</property>
+                    <property name="use-underline">True</property>
                     <child type="submenu">
                       <object class="GtkMenu" id="menu2">
                         <property name="can_focus">False</property>

--- a/gui/unified.go
+++ b/gui/unified.go
@@ -33,6 +33,7 @@ type unifiedLayout struct {
 	close        gtki.Button
 	convsVisible bool
 	inPageSet    bool
+	isFullscreen bool
 	itemMap      map[int]*conversationStackItem
 }
 
@@ -52,10 +53,11 @@ type conversationStackItem struct {
 
 func newUnifiedLayout(ui *gtkUI, left, parent gtki.Box) *unifiedLayout {
 	ul := &unifiedLayout{
-		ui:       ui,
-		cl:       &conversationList{},
-		leftPane: left,
-		itemMap:  make(map[int]*conversationStackItem),
+		ui:           ui,
+		cl:           &conversationList{},
+		leftPane:     left,
+		itemMap:      make(map[int]*conversationStackItem),
+		isFullscreen: false,
 	}
 	ul.cl.layout = ul
 
@@ -79,6 +81,7 @@ func newUnifiedLayout(ui *gtkUI, left, parent gtki.Box) *unifiedLayout {
 
 	connectShortcut("<Primary>Page_Down", ul.ui.window, ul.nextTab)
 	connectShortcut("<Primary>Page_Up", ul.ui.window, ul.previousTab)
+	connectShortcut("F11", ul.ui.window, ul.toggleFullscreen)
 
 	parent.PackStart(ul.rightPane, false, true, 0)
 	parent.SetChildPacking(ul.leftPane, false, true, 0, gtki.PACK_START)
@@ -349,6 +352,15 @@ func (ul *unifiedLayout) previousTab(gtki.Window) {
 	} else {
 		ul.notebook.SetCurrentPage(np)
 	}
+}
+
+func (ul *unifiedLayout) toggleFullscreen(gtki.Window) {
+	if ul.isFullscreen {
+		ul.ui.window.Unfullscreen()
+	} else {
+		ul.ui.window.Fullscreen()
+	}
+	ul.isFullscreen = !ul.isFullscreen
 }
 
 func (ul *unifiedLayout) update() {

--- a/gui/unified.go
+++ b/gui/unified.go
@@ -238,8 +238,9 @@ func (csi *conversationStackItem) bringToFront() {
 	csi.needsAttention = false
 	csi.applyTextWeight()
 	csi.layout.setCurrentPage(csi)
-	csi.layout.header.SetText(csi.to)
-	csi.layout.headerBar.SetSubtitle(csi.to)
+	title := fmt.Sprintf("%s <-> %s", csi.account.session.GetConfig().Account, csi.to)
+	csi.layout.header.SetText(title)
+	csi.layout.headerBar.SetSubtitle(title)
 	csi.entry.GrabFocus()
 }
 


### PR DESCRIPTION
Two small fixes:

 * Adding Super_L (alt) underscore accelerators to all the menus (5a89425).
 * Fixing the title of unified conversations to match that of non unified conversations (9b3ab8d).
 * Added fullscreen (F11) to unified window (1560369) [updated godeps - depends on https://github.com/twstrike/gotk3adapter/pull/2 ].
 * Added [XEP-0245](https://xmpp.org/extensions/xep-0245.html) support (`/me` action messages) for  #307 (64eefa4).