### PR TITLE
Small fixes - menu accels and unified window title and fullscreen

### DIFF
--- a/gui/definitions/ConversationPane.xml
+++ b/gui/definitions/ConversationPane.xml
@@ -9,7 +9,8 @@
         <child>
           <object class="GtkMenuItem" id="conversationMenu">
             <property name="visible">true</property>
-            <property name="label" translatable="yes">Developer options</property>
+            <property name="label" translatable="yes">_Developer options</property>
+            <property name="use-underline">True</property>
             <child type="submenu">
               <object class="GtkMenu" id="menu">
                 <property name="visible">true</property>

--- a/gui/definitions/Main.xml
+++ b/gui/definitions/Main.xml
@@ -19,7 +19,8 @@
                 <child>
                   <object class="GtkMenuItem" id="ContactsMenu">
                     <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Contacts</property>
+                    <property name="label" translatable="yes">_Contacts</property>
+                    <property name="use-underline">True</property>
                     <child type="submenu">
                       <object class="GtkMenu" id="menu">
                         <property name="can_focus">False</property>
@@ -37,13 +38,15 @@
                 <child>
                   <object class="GtkMenuItem" id="AccountsMenu">
                     <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Accounts</property>
+                    <property name="label" translatable="yes">_Accounts</property>
+                    <property name="use-underline">True</property>
                   </object>
                 </child>
                 <child>
                   <object class="GtkMenuItem" id="ViewMenu">
                     <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">View</property>
+                    <property name="label" translatable="yes">_View</property>
+                    <property name="use-underline">True</property>
                     <child type="submenu">
                       <object class="GtkMenu" id="menu2">
                         <property name="can_focus">False</property>

--- a/gui/definitions/conversation_pane.go
+++ b/gui/definitions/conversation_pane.go
@@ -18,7 +18,8 @@ func (*defConversationPane) String() string {
         <child>
           <object class="GtkMenuItem" id="conversationMenu">
             <property name="visible">true</property>
-            <property name="label" translatable="yes">Developer options</property>
+            <property name="label" translatable="yes">_Developer options</property>
+            <property name="use-underline">True</property>
             <child type="submenu">
               <object class="GtkMenu" id="menu">
                 <property name="visible">true</property>

--- a/gui/definitions/main.go
+++ b/gui/definitions/main.go
@@ -28,7 +28,8 @@ func (*defMain) String() string {
                 <child>
                   <object class="GtkMenuItem" id="ContactsMenu">
                     <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Contacts</property>
+                    <property name="label" translatable="yes">_Contacts</property>
+                    <property name="use-underline">True</property>
                     <child type="submenu">
                       <object class="GtkMenu" id="menu">
                         <property name="can_focus">False</property>
@@ -46,13 +47,15 @@ func (*defMain) String() string {
                 <child>
                   <object class="GtkMenuItem" id="AccountsMenu">
                     <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Accounts</property>
+                    <property name="label" translatable="yes">_Accounts</property>
+                    <property name="use-underline">True</property>
                   </object>
                 </child>
                 <child>
                   <object class="GtkMenuItem" id="ViewMenu">
                     <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">View</property>
+                    <property name="label" translatable="yes">_View</property>
+                    <property name="use-underline">True</property>
                     <child type="submenu">
                       <object class="GtkMenu" id="menu2">
                         <property name="can_focus">False</property>

--- a/gui/unified.go
+++ b/gui/unified.go
@@ -246,8 +246,9 @@ func (csi *conversationStackItem) bringToFront() {
 	csi.needsAttention = false
 	csi.applyTextWeight()
 	csi.layout.setCurrentPage(csi)
-	csi.layout.header.SetText(csi.to)
-	csi.layout.headerBar.SetSubtitle(csi.to)
+	title := fmt.Sprintf("%s <-> %s", csi.account.session.GetConfig().Account, csi.to)
+	csi.layout.header.SetText(title)
+	csi.layout.headerBar.SetSubtitle(title)
 	csi.entry.GrabFocus()
 }
 

--- a/gui/unified.go
+++ b/gui/unified.go
@@ -33,6 +33,7 @@ type unifiedLayout struct {
 	close        gtki.Button
 	convsVisible bool
 	inPageSet    bool
+	isFullscreen bool
 	itemMap      map[int]*conversationStackItem
 }
 
@@ -52,10 +53,11 @@ type conversationStackItem struct {
 
 func newUnifiedLayout(ui *gtkUI, left, parent gtki.Box) *unifiedLayout {
 	ul := &unifiedLayout{
-		ui:       ui,
-		cl:       &conversationList{},
-		leftPane: left,
-		itemMap:  make(map[int]*conversationStackItem),
+		ui:           ui,
+		cl:           &conversationList{},
+		leftPane:     left,
+		itemMap:      make(map[int]*conversationStackItem),
+		isFullscreen: false,
 	}
 	ul.cl.layout = ul
 
@@ -79,6 +81,7 @@ func newUnifiedLayout(ui *gtkUI, left, parent gtki.Box) *unifiedLayout {
 
 	connectShortcut("<Primary>Page_Down", ul.ui.window, ul.nextTab)
 	connectShortcut("<Primary>Page_Up", ul.ui.window, ul.previousTab)
+	connectShortcut("F11", ul.ui.window, ul.toggleFullscreen)
 
 	parent.PackStart(ul.rightPane, false, true, 0)
 	parent.SetChildPacking(ul.leftPane, false, true, 0, gtki.PACK_START)
@@ -353,6 +356,15 @@ func (ul *unifiedLayout) previousTab(gtki.Window) {
 	} else {
 		ul.notebook.SetCurrentPage(np)
 	}
+}
+
+func (ul *unifiedLayout) toggleFullscreen(gtki.Window) {
+	if ul.isFullscreen {
+		ul.ui.window.Unfullscreen()
+	} else {
+		ul.ui.window.Fullscreen()
+	}
+	ul.isFullscreen = !ul.isFullscreen
 }
 
 func (ul *unifiedLayout) update() {


### PR DESCRIPTION
 * Adding Super_L (alt) underscore accelerators to all the menus (184df2f).
 * Fixing the title of unified conversations to match that of non unified conversations (7d2c1de).
 * Added fullscreen (F11) to unified window (db7705e).