### PR TITLE
Add coyim.desktop template

### DIFF
--- a/build/coyim.desktop
+++ b/build/coyim.desktop
@@ -1,0 +1,20 @@
+# To integrate CoyIM with gnome-do place this file in either
+# your ~/.local/share/applications/ directory (you may need
+# to create this) or your /usr/share/applications/ directory.
+# Further details can be found here:
+# https://help.ubuntu.com/community/UnityLaunchersAndDesktopFiles
+
+[Desktop Entry]
+Name=CoyIM
+Comment=Secure Instant Messenger
+Exec=/usr/bin/coyim
+Terminal=false
+Type=Application
+# To enable the correct CoyIM icon, you can download Coy.icns from:
+# https://github.com/twstrike/coyim
+# It is in the directory build/mac-bundle.
+# You may place Coy.icns anywhere, but a better place would be either
+# ~/.local/share/icons/ (if .local is set up) or /usr/share/icons/
+# Then uncomment the below Icon field with the correct path
+# Icon=/path/to/Coy.icns
+Categories=Network;


### PR DESCRIPTION
Offers guidance around allowing gnome-do to launch CoyIM with the proper icons