### PR TITLE
Reverse logic of activation of "Connection info" button

### DIFF
--- a/gui/account.go
+++ b/gui/account.go
@@ -319,9 +319,9 @@ func (account *account) createSeparatorItem() gtki.MenuItem {
 func (account *account) createConnectionItem() gtki.MenuItem {
 	connInfoItem, _ := g.gtk.MenuItemNewWithMnemonic(i18n.Local("Connection _information..."))
 	connInfoItem.Connect("activate", account.connectionInfo)
-	connInfoItem.SetSensitive(!account.session.IsDisconnected())
+	connInfoItem.SetSensitive(account.session.IsConnected())
 	account.observeConnectionEvents(func() {
-		connInfoItem.SetSensitive(!account.session.IsDisconnected())
+		connInfoItem.SetSensitive(account.session.IsConnected())
 	})
 	return connInfoItem
 }


### PR DESCRIPTION
This leads to segfault while clicking on `Connection info` while connecting. This is because connection is `nil` at that time.